### PR TITLE
Fix versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-cell-lock",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "JupyterLab extension for easily locking cells, making them read-only and undeletable.",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
`labextension/package.json` in the released distributions incorrectly report `0.1.0` instead of `0.1.1`, causing JupyterLab to report the wrong version and request to update it `0.1.1` when this version was already installed.